### PR TITLE
OpenBSD V4L2 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ if test "${Darwin}" = ""; then
 	AC_MSG_RESULT(no)
 	AC_MSG_CHECKING(for *BSD)
 
-	FreeBSD=`uname -a | grep "BSD"`
+	FreeBSD=`uname -a | grep "FreeBSD"`
 	if test "${FreeBSD}" = ""; then
 		AC_MSG_RESULT(no)
 		VIDEO="video.o video2.o video_common.o"

--- a/configure.ac
+++ b/configure.ac
@@ -915,7 +915,7 @@ fi
 
 #Checks for header files.
 AC_HEADER_STDC
-AC_CHECK_HEADERS(stdio.h unistd.h stdint.h fcntl.h time.h signal.h sys/ioctl.h sys/mman.h linux/videodev.h linux/videodev2.h sys/param.h sys/types.h)
+AC_CHECK_HEADERS(stdio.h unistd.h stdint.h fcntl.h time.h signal.h sys/ioctl.h sys/mman.h linux/videodev.h linux/videodev2.h sys/param.h sys/types.h sys/videoio.h)
 
 AC_CHECK_FUNCS(get_current_dir_name)
 
@@ -931,8 +931,11 @@ else
 		[SUPPORTED_V4L2=true],
 		[SUPPORTED_V4L2=false],
 		[#include <sys/time.h>
-			#include <linux/videodev.h>])
-
+			#ifdef HAVE_LINUX_VIDEODEV_H
+			#include <linux/videodev.h>
+			#elif HAVE_SYS_VIDEOIO_H
+			#include <sys/videoio.h>
+			#endif])
 	AC_MSG_CHECKING(for V42L support)
 	if test x$SUPPORTED_V4L2 = xtrue; then
 		AC_MSG_RESULT(yes)

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -73,6 +73,7 @@ v4l2_palette 17
 
 # The video input to be used (default: -1)
 # Should normally be set to 0 or 1 for video/TV cards, and -1 for USB cameras
+# Set to 0 for uvideo(4) on OpenBSD
 input -1
 
 # The video norm to use (only for video capture and TV tuner cards)

--- a/motion.c
+++ b/motion.c
@@ -25,6 +25,7 @@
 /* Forward declarations */
 static int motion_init(struct context *cnt);
 static void motion_cleanup(struct context *cnt);
+static void setup_signals(struct sigaction *, struct sigaction *);
 
 
 /**

--- a/netcam_rtsp.c
+++ b/netcam_rtsp.c
@@ -19,8 +19,8 @@
  ***********************************************************/
 
 #include <stdio.h>
-#include "netcam_rtsp.h"
 #include "rotate.h"    /* already includes motion.h */
+#include "netcam_rtsp.h"
 
 #ifdef HAVE_FFMPEG
 

--- a/track.c
+++ b/track.c
@@ -9,7 +9,7 @@
 #include <math.h>
 #include "motion.h"
 
-#if defined(HAVE_LINUX_VIDEODEV_H) && (!defined(WITHOUT_V4L))
+#if (defined(HAVE_LINUX_VIDEODEV_H) || defined(HAVE_SYS_VIDEOIO_H)) && (!defined(WITHOUT_V4L))
 #include "pwc-ioctl.h"
 #endif
 

--- a/video.h
+++ b/video.h
@@ -14,8 +14,12 @@
 #include <sys/mman.h>
 
 
-#if defined(HAVE_LINUX_VIDEODEV_H) && (!defined(WITHOUT_V4L))
+#if !defined(WITHOUT_V4L)
+#if defined(HAVE_LINUX_VIDEODEV_H)
 #include <linux/videodev.h>
+#elif defined(HAVE_SYS_VIDEOIO_H)
+#include <sys/videoio.h>
+#endif
 #include "vloopback_motion.h"
 #include "pwc-ioctl.h"
 #endif

--- a/video2.c
+++ b/video2.c
@@ -179,7 +179,11 @@ typedef struct {
 /**
  * xioctl
  */
+#ifdef __OpenBSD__
+static int xioctl(int fd, unsigned long request, void *arg)
+#else
 static int xioctl(int fd, int request, void *arg)
+#endif
 {
     int ret;
 


### PR DESCRIPTION
This adds support to motion for OpenBSD's implementation of V4L2, works fine with a USB webcam using the uvideo(4) driver.