### PR TITLE
Fix typo. EMR is not a valid log level. Should be EMG

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -221,7 +221,7 @@ config_param config_params[] = {
     },
     {
     "log_level",
-    "# Level of log messages [1..9] (EMR, ALR, CRT, ERR, WRN, NTC, ERR, DBG, ALL). (default: 6 / NTC)",
+    "# Level of log messages [1..9] (EMG, ALR, CRT, ERR, WRN, NTC, ERR, DBG, ALL). (default: 6 / NTC)",
     1,
     CONF_OFFSET(log_level),
     copy_int,
@@ -2383,7 +2383,7 @@ static void usage()
     printf("-n\t\t\tRun in non-daemon mode.\n");
     printf("-s\t\t\tRun in setup mode.\n");
     printf("-c config\t\tFull path and filename of config file.\n");
-    printf("-d level\t\tLog level (1-9) (EMR, ALR, CRT, ERR, WRN, NTC, ERR, DBG, ALL). default: 6 / NTC.\n");
+    printf("-d level\t\tLog level (1-9) (EMG, ALR, CRT, ERR, WRN, NTC, ERR, DBG, ALL). default: 6 / NTC.\n");
     printf("-k type\t\t\tType of log (COR, STR, ENC, NET, DBL, EVT, TRK, VID, ALL). default: ALL.\n");
     printf("-p process_id_file\tFull path and filename of process id file (pid file).\n");
     printf("-l log file \t\tFull path and filename of log file.\n");

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -24,7 +24,7 @@ setup_mode off
 # Use a file to save logs messages, if not defined stderr and syslog is used. (default: not defined)
 ;logfile /tmp/motion.log
 
-# Level of log messages [1..9] (EMR, ALR, CRT, ERR, WRN, NTC, INF, DBG, ALL). (default: 6 / NTC)
+# Level of log messages [1..9] (EMG, ALR, CRT, ERR, WRN, NTC, INF, DBG, ALL). (default: 6 / NTC)
 log_level 6
 
 # Filter to log messages by type (COR, STR, ENC, NET, DBL, EVT, TRK, VID, ALL). (default: ALL)

--- a/motion.1
+++ b/motion.1
@@ -30,7 +30,7 @@ Run in non-daemon mode.
 Run in setup mode. Also forces non-daemon mode
 .TP
 .B \-d log level
-Set log level [1..9] (EMR, ALR, CRT, ERR, WRN, NTC, INF, DBG, ALL). (default: 6 / NTC)
+Set log level [1..9] (EMG, ALR, CRT, ERR, WRN, NTC, INF, DBG, ALL). (default: 6 / NTC)
 .TP
 .B \-k log type
 Set type of log (COR, STR, ENC, NET, DBL, EVT, TRK, VID, ALL). (default: ALL)
@@ -230,7 +230,7 @@ Use a file to save logs messages, if not defined stderr and syslog is used. ( if
 .B log_level integer
 Values: 1 - 9 / Default: 6
 .br
-Level of log messages [1..9] (EMR, ALR, CRT, ERR, WRN, NTC, ERR, DBG, ALL). (default: 6 / NTC).
+Level of log messages [1..9] (EMG, ALR, CRT, ERR, WRN, NTC, ERR, DBG, ALL). (default: 6 / NTC).
 .TP
 .B log_type discrete strings
 Values: STR, ENC, NET, DBL, EVT, TRK, VID, ALL / Default: ALL


### PR DESCRIPTION
Fix typo. EMR is not a valid log level. Should be EMG