### PR TITLE
lastsnap to allow path information when doing a singelton lastsnap picture

### DIFF
--- a/event.c
+++ b/event.c
@@ -350,8 +350,13 @@ static void event_image_snapshot(struct context *cnt, int type ATTRIBUTE_UNUSED,
             void *dummy2 ATTRIBUTE_UNUSED, struct tm *currenttime_tm)
 {
     char fullfilename[PATH_MAX];
-
-    if (strcmp(cnt->conf.snappath, "lastsnap")) {
+    int len = strlen(cnt->conf.snappath);
+    int offset = 0;
+    if (len >= 9)
+    {
+		offset = len - 8;
+	}
+    if (strcmp(cnt->conf.snappath+offset, "lastsnap")) {
         char filename[PATH_MAX];
         char filepath[PATH_MAX];
         char linkpath[PATH_MAX];
@@ -383,7 +388,11 @@ static void event_image_snapshot(struct context *cnt, int type ATTRIBUTE_UNUSED,
             return;
         }
     } else {
-        snprintf(fullfilename, PATH_MAX, "%s/lastsnap.%s", cnt->conf.filepath, imageext(cnt));
+		char filename[PATH_MAX];
+		char filepath[PATH_MAX];
+		mystrftime(cnt, filepath, sizeof(filepath), cnt->conf.snappath, currenttime_tm, NULL, 0);
+		snprintf(filename, PATH_MAX, "%s.%s", filepath, imageext(cnt));
+		snprintf(fullfilename, PATH_MAX, "%s/%s", cnt->conf.filepath, filename);
         remove(fullfilename);
         put_picture(cnt, fullfilename, img, FTYPE_IMAGE_SNAPSHOT);
     }


### PR DESCRIPTION
Currently pictures and movies can descend additional directories but the singleton "lastsnap" snapshot cannot. The current code determines if it is a singleton by comparing the snapshot_filename to "lastsnap".  This change looks for "lastsnap" at the end of snapshot_filename so other text can be in front to indicate additional directories or a further a prefix to the file name. This should not break existing implementations. 